### PR TITLE
fix: increase JSON body parser limit to 5MB

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -32,7 +32,7 @@ const wsProxy = createProxyMiddleware({
 })
 
 // Middleware
-app.use(express.json())
+app.use(express.json({ limit: '5mb' }))
 app.use(express.static(path.join(__dirname, '../public')))
 
 // Proxy DID document


### PR DESCRIPTION
## Summary
- Increases Express JSON body parser limit from default 100KB to 5MB
- Fixes `PayloadTooLargeError` when receiving profiles with avatar pictures

## Root Cause
Express's `express.json()` middleware defaults to a 100KB limit, which rejects requests containing larger payloads like profile pictures (~200KB+).

## Fix
Added `{ limit: '5mb' }` option to `express.json()` middleware in `src/bot.ts`.

Closes #3