### PR TITLE
feat: create LiveKit session on connect for instant avatar access

### DIFF
--- a/src/controllers/connection.controller.ts
+++ b/src/controllers/connection.controller.ts
@@ -1,15 +1,14 @@
 import { Request, Response } from 'express'
 import { ConnectionEstablishedDto } from '../dto'
-import { getAppConfig } from '../config'
-import { liveAvatarService, vsAgentService } from '../services'
 
 /**
  * Connection controller - handles new user connections
+ * Note: Welcome messages are sent via ProfileMessage handler in message.controller.ts
  */
 export class ConnectionController {
   /**
    * POST /connection-established - Handle new connections from VS Agent
-   * Sends welcome message with avatar link
+   * Just logs the connection - welcome flow is triggered by ProfileMessage
    */
   async handleConnectionEstablished(req: Request, res: Response): Promise<void> {
     try {
@@ -23,45 +22,9 @@ export class ConnectionController {
       }
 
       const connectionId = body.connectionId
-
       console.log(`🤝 New connection established: ${connectionId}`)
 
-      const config = getAppConfig()
-      const avatarLink = `${config.publicUrl}/avatar`
-
-      // Check if LiveAvatar is properly configured
-      const isConfigured = liveAvatarService.isConfigured()
-
-      // Build welcome message
-      const welcomeMessage = isConfigured
-        ? `👋 Welcome! I'm your Live Avatar assistant.\n\nTap the link below to start a video conversation with me!`
-        : `👋 Welcome! The Live Avatar demo is not fully configured yet. Please set up your HeyGen API credentials.`
-
-      // Send welcome text message using shared service
-      await vsAgentService.sendMessage(connectionId, {
-        type: 'text',
-        connectionId,
-        content: welcomeMessage,
-      })
-
-      // If configured, send the avatar link as a media message
-      if (isConfigured) {
-        await vsAgentService.sendMessage(connectionId, {
-          type: 'media',
-          connectionId,
-          items: [
-            {
-              mimeType: 'text/html',
-              uri: avatarLink,
-              title: '🎭 Start Live Avatar',
-              description: 'Tap to start a video conversation',
-              openingMode: 'fullScreen',
-            },
-          ],
-        })
-        console.log(`✅ Sent avatar link to connection ${connectionId}`)
-      }
-
+      // Welcome message will be sent when ProfileMessage is received via /message-received
       res.status(200).json({ success: true })
     } catch (error) {
       console.error('❌ Error handling connection:', error)

--- a/src/controllers/message.controller.ts
+++ b/src/controllers/message.controller.ts
@@ -9,13 +9,14 @@ import { liveAvatarService, vsAgentService } from '../services'
 export class MessageController {
   /**
    * POST /message-received - Webhook endpoint for VS Agent
+   * Handles different message types including profile and text messages
    */
   async handleMessageReceived(req: Request, res: Response): Promise<void> {
     try {
       const body = req.body as MessageReceivedDto
 
       // Input validation
-      if (!body?.message?.content || !body?.message?.connectionId) {
+      if (!body?.message?.connectionId) {
         console.error('❌ Invalid message payload:', JSON.stringify(body))
         res.status(400).json({ error: 'Invalid message payload' })
         return
@@ -23,59 +24,172 @@ export class MessageController {
 
       const message = body.message
       const connectionId = message.connectionId
-      const content = message.content.toLowerCase().trim()
+      const messageType = message.type
 
-      console.log(`📨 Message received from ${connectionId}: ${content}`)
+      console.log(`📨 Message received from ${connectionId}, type: ${messageType}`)
 
-      const config = getAppConfig()
-      const avatarLink = `${config.publicUrl}/avatar`
-
-      let responseContent: string
-      let sendAvatarLink = false
-
-      // Handle commands
-      if (content === '/start' || content === '/avatar' || content === 'start') {
-        if (liveAvatarService.isConfigured()) {
-          responseContent = `🎭 Great! Let's start your Live Avatar session.\n\nTap the link below to begin:`
-          sendAvatarLink = true
-        } else {
-          responseContent = `⚠️ The Live Avatar is not configured. Please set up your HeyGen API credentials in the .env file.`
-        }
-      } else if (content === '/help' || content === 'help') {
-        responseContent = `🤖 **Live Avatar Agent Commands:**\n\n• \`/start\` - Start a video avatar session\n• \`/help\` - Show this help message\n\nOr just say "start" to begin!`
-      } else {
-        // Default response
-        responseContent = `👋 Hi! I'm the Live Avatar agent.\n\nSay \`start\` or \`/start\` to begin a video conversation with the avatar!`
+      // Handle profile message - send welcome with direct session
+      if (messageType === 'profile') {
+        await this.handleProfileMessage(connectionId, message.displayName)
+        res.status(200).end()
+        return
       }
 
-      // Send text response using shared service
-      await vsAgentService.sendMessage(connectionId, {
-        type: 'text',
-        connectionId,
-        content: responseContent,
-      })
-
-      // Send avatar link if needed
-      if (sendAvatarLink) {
-        await vsAgentService.sendMessage(connectionId, {
-          type: 'media',
-          connectionId,
-          items: [
-            {
-              mimeType: 'text/html',
-              uri: avatarLink,
-              title: '🎭 Start Live Avatar',
-              description: 'Tap to start a video conversation',
-              openingMode: 'fullScreen',
-            },
-          ],
-        })
+      // Handle text messages
+      if (messageType === 'text' && message.content) {
+        await this.handleTextMessage(connectionId, message.content)
+        res.status(200).end()
+        return
       }
 
+      // Unknown message type - just acknowledge
+      console.log(`ℹ️ Unhandled message type: ${messageType}`)
       res.status(200).end()
     } catch (error) {
       console.error('❌ Error processing message:', error)
       res.status(500).json({ error: 'Internal server error' })
+    }
+  }
+
+  /**
+   * Handle profile message - create session and send welcome
+   */
+  private async handleProfileMessage(connectionId: string, displayName?: string): Promise<void> {
+    console.log(`👤 Profile message from ${connectionId}${displayName ? ` (${displayName})` : ''}`)
+
+    const isConfigured = liveAvatarService.isConfigured()
+
+    if (!isConfigured) {
+      await vsAgentService.sendMessage(connectionId, {
+        type: 'text',
+        connectionId,
+        content: `👋 Welcome! The Live Avatar demo is not fully configured yet. Please set up your HeyGen API credentials.`,
+      })
+      return
+    }
+
+    // Try to create session immediately
+    let directSessionUrl: string | null = null
+    let creditsExhausted = false
+
+    try {
+      console.log(`🎬 Creating LiveKit session for ${connectionId}...`)
+      const { sessionToken } = await liveAvatarService.createSessionToken()
+      const { livekitUrl, livekitToken } = await liveAvatarService.startSession(sessionToken)
+
+      // Build direct LiveKit Meet URL
+      directSessionUrl = `https://meet.livekit.io/custom?liveKitUrl=${encodeURIComponent(livekitUrl)}&token=${encodeURIComponent(livekitToken)}`
+      console.log(`✅ Session created for ${connectionId}`)
+    } catch (sessionError) {
+      const errorMessage = (sessionError as Error).message
+      console.error(`⚠️ Failed to create session for ${connectionId}:`, sessionError)
+
+      // Check if credits are exhausted
+      if (errorMessage.includes('Insufficient credits')) {
+        creditsExhausted = true
+        console.log(`💳 Credits exhausted for ${connectionId}`)
+      }
+    }
+
+    // Handle credits exhausted case
+    if (creditsExhausted) {
+      await vsAgentService.sendMessage(connectionId, {
+        type: 'text',
+        connectionId,
+        content: `👋 Hi! I'm the Live Avatar agent.\n\n⚠️ Unfortunately, the LiveAvatar API credits have been exhausted. Please contact the administrator to restore the service.\n\nWe apologize for the inconvenience!`,
+      })
+      console.log(`✅ Credits exhausted message sent to ${connectionId}`)
+      return
+    }
+
+    // Send welcome message
+    const welcomeMessage = directSessionUrl
+      ? `👋 Hi, I'm the live avatar agent. Let's start your live avatar session and click open to start.`
+      : `👋 Welcome! I'm your Live Avatar assistant.\n\nTap the link below to start a video conversation with me!`
+
+    await vsAgentService.sendMessage(connectionId, {
+      type: 'text',
+      connectionId,
+      content: welcomeMessage,
+    })
+
+    // Send session link (direct or fallback to /avatar)
+    const config = getAppConfig()
+    const sessionUrl = directSessionUrl ?? `${config.publicUrl}/avatar`
+
+    await vsAgentService.sendMessage(connectionId, {
+      type: 'media',
+      connectionId,
+      items: [
+        {
+          mimeType: 'text/html',
+          uri: sessionUrl,
+          title: '🎭 Open Live Avatar',
+          description: 'Tap to start your video conversation',
+          openingMode: 'fullScreen',
+        },
+      ],
+    })
+
+    console.log(
+      `✅ Welcome sent to ${connectionId}${directSessionUrl ? ' (direct session)' : ' (fallback)'}`
+    )
+  }
+
+  /**
+   * Handle text message - process commands
+   */
+  private async handleTextMessage(connectionId: string, content: string): Promise<void> {
+    const normalizedContent = content.toLowerCase().trim()
+    console.log(`💬 Text message from ${connectionId}: ${normalizedContent}`)
+
+    const config = getAppConfig()
+    const avatarLink = `${config.publicUrl}/avatar`
+
+    let responseContent: string
+    let sendAvatarLink = false
+
+    // Handle commands
+    if (
+      normalizedContent === '/start' ||
+      normalizedContent === '/avatar' ||
+      normalizedContent === 'start'
+    ) {
+      if (liveAvatarService.isConfigured()) {
+        responseContent = `🎭 Great! Let's start your Live Avatar session.\n\nTap the link below to begin:`
+        sendAvatarLink = true
+      } else {
+        responseContent = `⚠️ The Live Avatar is not configured. Please set up your HeyGen API credentials in the .env file.`
+      }
+    } else if (normalizedContent === '/help' || normalizedContent === 'help') {
+      responseContent = `🤖 **Live Avatar Agent Commands:**\n\n• \`/start\` - Start a video avatar session\n• \`/help\` - Show this help message\n\nOr just say "start" to begin!`
+    } else {
+      // Default response
+      responseContent = `👋 Hi! I'm the Live Avatar agent.\n\nSay \`start\` or \`/start\` to begin a video conversation with the avatar!`
+    }
+
+    // Send text response
+    await vsAgentService.sendMessage(connectionId, {
+      type: 'text',
+      connectionId,
+      content: responseContent,
+    })
+
+    // Send avatar link if needed
+    if (sendAvatarLink) {
+      await vsAgentService.sendMessage(connectionId, {
+        type: 'media',
+        connectionId,
+        items: [
+          {
+            mimeType: 'text/html',
+            uri: avatarLink,
+            title: '🎭 Start Live Avatar',
+            description: 'Tap to start a video conversation',
+            openingMode: 'fullScreen',
+          },
+        ],
+      })
     }
   }
 }

--- a/src/dto/index.ts
+++ b/src/dto/index.ts
@@ -6,17 +6,17 @@ export interface MessageReceivedDto {
   message: {
     connectionId: string
     type: string
-    content: string
+    content?: string
     threadId?: string
+    // Profile message fields
+    displayName?: string
+    displayImageUrl?: string
+    displayIconUrl?: string
+    preferredLanguage?: string
   }
 }
 
 export interface ConnectionEstablishedDto {
   connectionId: string
   language?: string
-}
-
-export interface WelcomeResponseDto {
-  message: string
-  avatarLink: string
 }


### PR DESCRIPTION
## Summary

This PR simplifies the user experience by creating a LiveKit session immediately when a user connects to the bot, allowing them to access the live avatar instantly without additional redirects.

### Changes

- **Direct session creation**: When a user connects and sends a ProfileMessage, the bot now creates a LiveKit session immediately and sends a direct LiveKit Meet URL
- **Improved welcome flow**: Users receive a welcome message with a pre-created session link - clicking "Open" takes them directly to the active session
- **Graceful fallback**: If session creation fails (e.g., API issues), falls back to the `/avatar` redirect endpoint
- **Credits exhausted handling**: Detects when HeyGen API credits are exhausted and shows a user-friendly message instead of a white page
- **Styled error pages**: Added a proper HTML error page for the `/avatar` endpoint to handle various error scenarios

### Before

1. User connects → Bot sends welcome + `/avatar` link
2. User clicks link → GET `/avatar` creates session → Redirects to LiveKit
3. User waits during redirect

### After

1. User connects → Bot creates session immediately
2. Bot sends welcome + direct LiveKit URL with credentials
3. User clicks "Open" → Goes directly to active session (no redirect)

## Test plan

- [x] Connect to the bot via Hologram app
- [x] Verify welcome message appears with "Open Live Avatar" button
- [x] Verify clicking "Open" goes directly to LiveKit session
- [x] Test fallback by simulating session creation failure
- [x] Test credits exhausted scenario shows proper error message